### PR TITLE
Add Masjid subscriptions

### DIFF
--- a/generator/serverless.yml
+++ b/generator/serverless.yml
@@ -6,14 +6,19 @@ frameworkVersion: '3'
 params:
   dev:
     s3_bucket: wwpray-dev
+    # TODO later configure using a CNAME
+    subscriptions_base_url: https://lgigm92nn6.execute-api.us-east-1.amazonaws.com
   prod:
     s3_bucket: wwpray-prod
+    # TODO later configure using a CNAME
+    subscriptions_base_url: TODO
 
 provider:
   name: aws
   runtime: nodejs18.x
   environment:
     S3_BUCKET: ${param:s3_bucket}
+    PUBLIC_SUBSCRIPTIONS_BASE_URL: ${param:subscriptions_base_url}
   iam:
     role:
       statements:

--- a/generator/svelte/src/lib/components/Alert.svelte
+++ b/generator/svelte/src/lib/components/Alert.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import { ALERT_PATHS, EAlertType } from '$lib/constants';
+	import { ALERT_ICONS, EAlertType } from '$lib/constants';
+	import Icon from '@krowten/svelte-heroicons/Icon.svelte';
 
 	export let type = EAlertType.Info;
 	let classes = '';
@@ -7,17 +8,7 @@
 </script>
 
 <div class="alert {type} {classes}">
-	<svg
-		xmlns="http://www.w3.org/2000/svg"
-		class="stroke-current shrink-0 h-6 w-6"
-		fill="none"
-		stroke-linecap="round"
-		stroke-linejoin="round"
-		stroke-width="2"
-		viewBox="0 0 24 24"
-	>
-		<path d={ALERT_PATHS[type]} />
-	</svg>
+	<Icon name={ALERT_ICONS[type]} class="w-6 h-6 text-current" />
 	<span>
 		<slot />
 	</span>

--- a/generator/svelte/src/lib/components/Alert.svelte
+++ b/generator/svelte/src/lib/components/Alert.svelte
@@ -2,9 +2,11 @@
 	import { ALERT_PATHS, EAlertType } from '$lib/constants';
 
 	export let type = EAlertType.Info;
+	let classes = '';
+	export { classes as class };
 </script>
 
-<div class="alert {type}">
+<div class="alert {type} {classes}">
 	<svg
 		xmlns="http://www.w3.org/2000/svg"
 		class="stroke-current shrink-0 h-6 w-6"

--- a/generator/svelte/src/lib/components/Alert.svelte
+++ b/generator/svelte/src/lib/components/Alert.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import { ALERT_PATHS, EAlertType } from '$lib/constants';
+
+	export let type = EAlertType.Info;
+</script>
+
+<div class="alert {type}">
+	<svg
+		xmlns="http://www.w3.org/2000/svg"
+		class="stroke-current shrink-0 h-6 w-6"
+		fill="none"
+		stroke-linecap="round"
+		stroke-linejoin="round"
+		stroke-width="2"
+		viewBox="0 0 24 24"
+	>
+		<path d={ALERT_PATHS[type]} />
+	</svg>
+	<span>
+		<slot />
+	</span>
+</div>

--- a/generator/svelte/src/lib/components/SideOver.svelte
+++ b/generator/svelte/src/lib/components/SideOver.svelte
@@ -3,10 +3,12 @@
 		id: string;
 		'close-aria-label': string;
 	};
+
+	export let sideInput: HTMLInputElement;
 </script>
 
 <div class="drawer drawer-end">
-	<input {id} type="checkbox" class="drawer-toggle" />
+	<input bind:this={sideInput} {id} type="checkbox" class="drawer-toggle" />
 	<div class="drawer-content">
 		<slot name="page" />
 	</div>

--- a/generator/svelte/src/lib/components/SideOver.svelte
+++ b/generator/svelte/src/lib/components/SideOver.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	export let { id, ...props } = $$props as {
+		id: string;
+		'close-aria-label': string;
+	};
+</script>
+
+<div class="drawer drawer-end">
+	<input {id} type="checkbox" class="drawer-toggle" />
+	<div class="drawer-content">
+		<slot name="page" />
+	</div>
+	<div class="drawer-side z-[100]">
+		<label for={id} aria-label={props['close-aria-label']} class="drawer-overlay" />
+		<div
+			class="relative menu p-4 w-[clamp(320px,90vw,420px)] min-h-full bg-base-200 text-base-content"
+		>
+			<slot name="side" />
+		</div>
+	</div>
+</div>

--- a/generator/svelte/src/lib/components/Spacer.svelte
+++ b/generator/svelte/src/lib/components/Spacer.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	const SIZES = {
+		x: {
+			sm: 'w-1',
+			md: 'w-2',
+			lg: 'w-3',
+			xl: 'w-4'
+		},
+		y: {
+			sm: 'h-1',
+			md: 'h-2',
+			lg: 'h-3',
+			xl: 'h-4'
+		}
+	} as const;
+
+	export let size: keyof (typeof SIZES)['y'] = 'sm';
+	export let axis: keyof typeof SIZES = 'y';
+</script>
+
+<div class={SIZES[axis][size]} />

--- a/generator/svelte/src/lib/components/Toast.svelte
+++ b/generator/svelte/src/lib/components/Toast.svelte
@@ -9,7 +9,7 @@
 
 <div transition:fly={{ y: -16, duration: 300 }} class="alert {type} {classes}">
 	<div class="flex items-center gap-2 text-white font-bold">
-		<Icon name={ALERT_ICONS[type]} class="h-6 w-6 text-crrent" />
+		<Icon name={ALERT_ICONS[type]} class="min-w-[1.5rem] min-h-[1.5rem] w-6 h-6 text-crrent" />
 		<span>
 			<slot />
 		</span>

--- a/generator/svelte/src/lib/service.ts
+++ b/generator/svelte/src/lib/service.ts
@@ -1,0 +1,27 @@
+import { PUBLIC_SUBSCRIPTIONS_BASE_URL } from '$env/static/public';
+import { toast } from './stores/toast';
+import type { ISubscribeArgs, ISubscribeResponse } from './types';
+
+export const subscribeToMasjid = async ({ email, topics }: ISubscribeArgs) => {
+	const url = new URL(PUBLIC_SUBSCRIPTIONS_BASE_URL);
+	url.searchParams.append('email', email);
+	for (const topic of topics) {
+		url.searchParams.append('topics', topic);
+	}
+
+	const response = await fetch(url, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			Accept: 'application/json'
+		}
+	});
+
+	const data = (await response.json()) satisfies ISubscribeResponse;
+
+	if (!response.ok) {
+		toast.error(data?.message ?? 'An error occurred');
+	}
+
+	data.message && toast.success(data.message);
+};

--- a/generator/svelte/src/lib/service.ts
+++ b/generator/svelte/src/lib/service.ts
@@ -12,7 +12,6 @@ export const subscribeToMasjid = async ({ email, topics }: ISubscribeArgs) => {
 	const response = await fetch(url, {
 		method: 'POST',
 		headers: {
-			'Content-Type': 'application/json',
 			Accept: 'application/json'
 		}
 	});

--- a/generator/svelte/src/lib/types.ts
+++ b/generator/svelte/src/lib/types.ts
@@ -4,6 +4,12 @@ export interface IToast {
 	type: EAlertType;
 	message: string;
 }
+
+export interface ISubscribeArgs {
+	email: string;
+	topics: string[];
+}
+
 export interface ISubscribeResponse {
 	message: string;
 	topics: string[];

--- a/generator/svelte/src/lib/types.ts
+++ b/generator/svelte/src/lib/types.ts
@@ -4,3 +4,7 @@ export interface IToast {
 	type: EAlertType;
 	message: string;
 }
+export interface ISubscribeResponse {
+	message: string;
+	topics: string[];
+}

--- a/generator/svelte/src/routes/+layout.svelte
+++ b/generator/svelte/src/routes/+layout.svelte
@@ -6,9 +6,11 @@
 	import '../app.css';
 </script>
 
-<ul class="fixed top-navbar left-1/2 -translate-x-1/2 translate-y-8 flex flex-col gap-4 z-[100]">
+<ul
+	class="fixed inset-0 top-navbar left-1/2 -translate-x-1/2 translate-y-8 flex flex-col gap-4 z-[200] pointer-events-none"
+>
 	{#each $toasts as toast (toast.message)}
-		<li animate:flip>
+		<li class="pointer-events-auto" animate:flip>
 			<Toast type={toast.type}>
 				{toast.message}
 			</Toast>

--- a/generator/svelte/src/routes/+page.svelte
+++ b/generator/svelte/src/routes/+page.svelte
@@ -8,6 +8,7 @@
 	import SideOver from '$lib/components/SideOver.svelte';
 	import { env } from '$env/dynamic/public';
 	import Spacer from '$lib/components/Spacer.svelte';
+	import Alert from '$lib/components/Alert.svelte';
 
 	// This data object is the one returned by the load function
 	// wait we didn't assign it to anything, how does it work?
@@ -17,6 +18,7 @@
 	// Reactive declarations, those are re-evaluated when the variables they depend on change.
 	$: url = $page.url;
 	$: search = browser && url.searchParams.get('search');
+	$: message = browser && url.searchParams.get('message');
 	$: masjids = entries(data.masjids).filter(([name]) => {
 		if (!search) return true;
 		return name.toLowerCase().includes(search.toLowerCase());
@@ -51,6 +53,12 @@
 			View prayer times for various masjids below. To find a specific masjid, use the search bar at
 			the top.
 		</p>
+
+		{#if message}
+			<Spacer />
+			<Alert>{message}</Alert>
+			<Spacer />
+		{/if}
 
 		<div class="px-8 w-full capitalize">
 			{#each masjids as [name, { iqamas, jumas }], i}

--- a/generator/svelte/src/routes/+page.svelte
+++ b/generator/svelte/src/routes/+page.svelte
@@ -5,6 +5,10 @@
 	import entries from 'lodash/entries';
 	import { browser } from '$app/environment';
 	import { APP_NAME } from '$lib/constants';
+	import SideOver from '$lib/components/SideOver.svelte';
+	import { env } from '$env/dynamic/public';
+	import { enhance } from '$app/forms';
+	import Spacer from '$lib/components/Spacer.svelte';
 
 	// This data object is the one returned by the load function
 	// wait we didn't assign it to anything, how does it work?
@@ -18,6 +22,9 @@
 		if (!search) return true;
 		return name.toLowerCase().includes(search.toLowerCase());
 	});
+
+	const SUBSCRIPTION_SIDEOVER_ID = 'subscription-sideover';
+	const SUBSCRIPTIONS_BASE_URL = env.PUBLIC_SUBSCRIPTIONS_BASE_URL;
 </script>
 
 <svelte:head>
@@ -25,48 +32,102 @@
 	<meta name="description" content="Prayer times for various masjids in tabular format" />
 </svelte:head>
 
-<div class="mx-auto prose max-w-6xl py-12 px-6 lg:px-8">
-	<h1>Masjid Prayer Times</h1>
-	<p>
-		View prayer times for various masjids below. To find a specific masjid, use the search bar at
-		the top.
-	</p>
+<SideOver id={SUBSCRIPTION_SIDEOVER_ID} close-aria-label="close subscriptions sideover">
+	<div slot="page" class="mx-auto prose max-w-6xl py-12 px-6 lg:px-8">
+		<h1>Masjid Prayer Times</h1>
+		<p>
+			View prayer times for various masjids below. To find a specific masjid, use the search bar at
+			the top.
+		</p>
 
-	<div class="w-full capitalize">
-		{#each masjids as [name, { iqamas, jumas }], i}
-			<h2>{name}</h2>
-			<div class="overflow-x-auto px-4">
-				<table class="table table-zebra">
-					<thead>
-						<tr>
-							<th>Iqama</th>
-							<th>Time</th>
-						</tr>
-					</thead>
-					<tbody>
-						{#each entries(iqamas) as [iqama, { time }]}
+		<div class="w-full capitalize">
+			{#each masjids as [name, { iqamas, jumas }], i}
+				<div class="flex items-center justify-between">
+					<h2>{name}</h2>
+
+					<label for={SUBSCRIPTION_SIDEOVER_ID} class="btn btn-primary drawer-button">
+						Subscribe
+					</label>
+				</div>
+				<div class="overflow-x-auto px-4">
+					<table class="table table-zebra">
+						<thead>
 							<tr>
-								<td>{iqama}</td>
-								<td>{time}</td>
+								<th>Iqama</th>
+								<th>Time</th>
 							</tr>
+						</thead>
+						<tbody>
+							{#each entries(iqamas) as [iqama, { time }]}
+								<tr>
+									<td>{iqama}</td>
+									<td>{time}</td>
+								</tr>
+							{/each}
+						</tbody>
+					</table>
+					<h3>Jumas</h3>
+					<ul>
+						{#each jumas as juma}
+							<li>
+								{juma}
+							</li>
 						{/each}
-					</tbody>
-				</table>
-				<h3>Jumas</h3>
-				<ul>
-					{#each jumas as juma}
-						<li>
-							{juma}
-						</li>
-					{/each}
-				</ul>
-			</div>
-			{#if i !== masjids.length - 1}
-				<Divider />
-			{/if}
-		{/each}
+					</ul>
+				</div>
+				{#if i !== masjids.length - 1}
+					<Divider />
+				{/if}
+			{/each}
+		</div>
 	</div>
-</div>
+
+	<form
+		slot="side"
+		class="flex flex-col flex-grow min-h-0 px-2 py-4 prose prose-li:my-0 prose-ul:px-0"
+		method="GET"
+		action={SUBSCRIPTIONS_BASE_URL}
+		use:enhance
+	>
+		<h2>Subscribe to Masjid Prayer Times</h2>
+
+		<div class="form-control w-full">
+			<label for="email" class="label">
+				<span class="label-text text-base font-medium">What is your email?</span>
+			</label>
+			<input
+				type="email"
+				name="email"
+				id="email"
+				placeholder="Type your email here"
+				class="input input-bordered w-full"
+			/>
+		</div>
+		<Spacer size="lg" />
+		<label for="topics" class="label text-base font-medium">
+			<span>Which masjids do you want to subscribe to?</span>
+		</label>
+		<ul class="w-full mt-1">
+			{#each masjids as [name]}
+				<li>
+					<label class="label justify-start cursor-pointer my-1">
+						<input type="checkbox" name="topics" class="checkbox checkbox-primary" value={name} />
+						<span class="label-text">{name}</span>
+					</label>
+				</li>
+			{/each}
+		</ul>
+		<div class="mt-auto flex items-center gap-4">
+			<button class="btn btn-primary flex-[0.8]" type="submit"> Subscribe </button>
+			<label
+				for={SUBSCRIPTION_SIDEOVER_ID}
+				class="flex-[0.2] btn btn-outline btn-neutral drawer-button"
+			>
+				Close
+			</label>
+		</div>
+	</form>
+</SideOver>
 
 <style>
 	.prose {

--- a/generator/svelte/src/routes/+page.svelte
+++ b/generator/svelte/src/routes/+page.svelte
@@ -45,13 +45,13 @@
 			the top.
 		</p>
 
-		<div class="w-full capitalize">
+		<div class="px-8 w-full capitalize">
 			{#each masjids as [name, { iqamas, jumas }], i}
 				<h2 class="flex items-center justify-between">
 					<span>{name}</span>
 
 					<button on:click={() => onMasjidSubscription(name)}>
-						<label class="btn btn-primary drawer-button" for={SUBSCRIPTION_SIDEOVER_ID}>
+						<label class="btn btn-primary btn-sm drawer-button" for={SUBSCRIPTION_SIDEOVER_ID}>
 							Subscribe
 						</label>
 					</button>

--- a/generator/svelte/src/routes/+page.svelte
+++ b/generator/svelte/src/routes/+page.svelte
@@ -41,6 +41,7 @@
 		checkbox.checked = true;
 	};
 
+	export let sideInput: HTMLInputElement;
 	// Progressive Enhancement
 	// Works in case JS is enabled, otherwise the form will be submitted normally
 	const onMasjidSubscribeSubmit = (e: Event) => {
@@ -62,6 +63,8 @@
 		}
 
 		subscribeToMasjid({ email, topics });
+
+		sideInput.checked = false;
 	};
 </script>
 
@@ -70,7 +73,11 @@
 	<meta name="description" content="Prayer times for various masjids in tabular format" />
 </svelte:head>
 
-<SideOver id={SUBSCRIPTION_SIDEOVER_ID} close-aria-label="close subscriptions sideover">
+<SideOver
+	bind:sideInput
+	id={SUBSCRIPTION_SIDEOVER_ID}
+	close-aria-label="close subscriptions sideover"
+>
 	<div slot="page" class="mx-auto prose max-w-6xl py-12 px-6 lg:px-8">
 		<h1>Masjid Prayer Times</h1>
 		<p>

--- a/generator/svelte/src/routes/+page.svelte
+++ b/generator/svelte/src/routes/+page.svelte
@@ -25,6 +25,11 @@
 
 	const SUBSCRIPTION_SIDEOVER_ID = 'subscription-sideover';
 	const SUBSCRIPTIONS_BASE_URL = env.PUBLIC_SUBSCRIPTIONS_BASE_URL;
+
+	let chosenMasjid: (typeof masjids)[number][0] | null;
+	const onMasjidSubscription = (masjid: typeof chosenMasjid) => {
+		chosenMasjid = masjid;
+	};
 </script>
 
 <svelte:head>
@@ -42,13 +47,16 @@
 
 		<div class="w-full capitalize">
 			{#each masjids as [name, { iqamas, jumas }], i}
-				<div class="flex items-center justify-between">
-					<h2>{name}</h2>
+				<h2 class="flex items-center justify-between">
+					<span>{name}</span>
 
-					<label for={SUBSCRIPTION_SIDEOVER_ID} class="btn btn-primary drawer-button">
-						Subscribe
-					</label>
-				</div>
+					<button on:click={() => onMasjidSubscription(name)}>
+						<label class="btn btn-primary drawer-button" for={SUBSCRIPTION_SIDEOVER_ID}>
+							Subscribe
+						</label>
+					</button>
+				</h2>
+
 				<div class="overflow-x-auto px-4">
 					<table class="table table-zebra">
 						<thead>
@@ -111,7 +119,15 @@
 			{#each masjids as [name]}
 				<li>
 					<label class="label justify-start cursor-pointer my-1">
-						<input type="checkbox" name="topics" class="checkbox checkbox-primary" value={name} />
+						<input
+							id={name}
+							type="checkbox"
+							name="topics"
+							class="checkbox checkbox-primary"
+							value={name}
+							checked={chosenMasjid === name || undefined}
+							on:change={() => (chosenMasjid = null)}
+						/>
 						<span class="label-text">{name}</span>
 					</label>
 				</li>

--- a/generator/svelte/src/routes/+page.svelte
+++ b/generator/svelte/src/routes/+page.svelte
@@ -102,7 +102,6 @@
 		class="flex flex-col flex-grow min-h-0 px-2 py-4 prose prose-li:my-0 prose-ul:px-0"
 		method="GET"
 		action={SUBSCRIPTIONS_BASE_URL}
-		on:submit|preventDefault
 	>
 		<h2>Subscribe to Masjid Prayer Times</h2>
 

--- a/generator/svelte/src/routes/+page.svelte
+++ b/generator/svelte/src/routes/+page.svelte
@@ -100,7 +100,7 @@
 	<form
 		slot="side"
 		class="flex flex-col flex-grow min-h-0 px-2 py-4 prose prose-li:my-0 prose-ul:px-0"
-		method="POST"
+		method="GET"
 		action={SUBSCRIPTIONS_BASE_URL}
 	>
 		<h2>Subscribe to Masjid Prayer Times</h2>

--- a/generator/svelte/src/routes/+page.svelte
+++ b/generator/svelte/src/routes/+page.svelte
@@ -7,7 +7,6 @@
 	import { APP_NAME } from '$lib/constants';
 	import SideOver from '$lib/components/SideOver.svelte';
 	import { env } from '$env/dynamic/public';
-	import { enhance } from '$app/forms';
 	import Spacer from '$lib/components/Spacer.svelte';
 
 	// This data object is the one returned by the load function
@@ -26,9 +25,17 @@
 	const SUBSCRIPTION_SIDEOVER_ID = 'subscription-sideover';
 	const SUBSCRIPTIONS_BASE_URL = env.PUBLIC_SUBSCRIPTIONS_BASE_URL;
 
-	let chosenMasjid: (typeof masjids)[number][0] | null;
-	const onMasjidSubscription = (masjid: typeof chosenMasjid) => {
-		chosenMasjid = masjid;
+	let masjidsList: HTMLUListElement;
+	const onMasjidSubscription = (name: string) => {
+		const checkbox = masjidsList.querySelector<HTMLInputElement>(`#${name}`);
+
+		if (!checkbox) {
+			alert('err');
+			// TODO setup a toast system and show error here
+			return;
+		}
+
+		checkbox.checked = true;
 	};
 </script>
 
@@ -95,7 +102,7 @@
 		class="flex flex-col flex-grow min-h-0 px-2 py-4 prose prose-li:my-0 prose-ul:px-0"
 		method="GET"
 		action={SUBSCRIPTIONS_BASE_URL}
-		use:enhance
+		on:submit|preventDefault
 	>
 		<h2>Subscribe to Masjid Prayer Times</h2>
 
@@ -115,7 +122,7 @@
 		<label for="topics" class="label text-base font-medium">
 			<span>Which masjids do you want to subscribe to?</span>
 		</label>
-		<ul class="w-full mt-1">
+		<ul class="w-full mt-1" bind:this={masjidsList}>
 			{#each masjids as [name]}
 				<li>
 					<label class="label justify-start cursor-pointer my-1">
@@ -125,8 +132,6 @@
 							name="topics"
 							class="checkbox checkbox-primary"
 							value={name}
-							checked={chosenMasjid === name || undefined}
-							on:change={() => (chosenMasjid = null)}
 						/>
 						<span class="label-text">{name}</span>
 					</label>

--- a/generator/svelte/src/routes/+page.svelte
+++ b/generator/svelte/src/routes/+page.svelte
@@ -100,7 +100,7 @@
 	<form
 		slot="side"
 		class="flex flex-col flex-grow min-h-0 px-2 py-4 prose prose-li:my-0 prose-ul:px-0"
-		method="GET"
+		method="POST"
 		action={SUBSCRIPTIONS_BASE_URL}
 	>
 		<h2>Subscribe to Masjid Prayer Times</h2>


### PR DESCRIPTION
Allow users to subscribe to one or more masjids using their email address:

- How it works?
Each masjid has a `subscribe` button beside it's name. If clicked, it will open a SideOver element with a form element with an `email` field and a checkbox for each masjid.

When we have the compact view, we could add a checkbox to the table or make it even simpler by adding the `subscribe` functionality as a table column.

- Features: 
  - Works with Zero JS. We get this done by using `input` and `label` elements, the whole SideOver element could be treated as a checkbox, and all we use is native built-in HTML functionality.
  - Progressive Enhancements: When having JS, the experience will be better, E.p: checking the masjid in place of the user when `subscribe` is clicked.

## Images

### Successful subscription
<img width="973" alt="image" src="https://github.com/hammady/wwpray/assets/49946791/6a396ff5-7511-4da8-bb20-3ba903b0e061">

### Already Subscribed
![2023-10-16 06 57 15](https://github.com/hammady/wwpray/assets/49946791/7a5fe9db-7f04-4597-858c-105d991bd2ba)

### No-JS
NOTE: It turned out that displaying the message in No-JS mode requires SSR. For static, we don't have a server to display them, but anyway, it's not a big deal as they get an email confirmation message.

![2023-10-16 07 09 48](https://github.com/hammady/wwpray/assets/49946791/e941aa18-111e-4e4c-aa1e-ef87aa5a5e1f)
