### PR TITLE
Support GET in subscribe and multiple response formats

### DIFF
--- a/subscriber/handler.py
+++ b/subscriber/handler.py
@@ -22,7 +22,7 @@ def run(event, context):
         if headers is not None:
             accept_header = headers.get("accept") or headers.get("Accept")
             referer_header = headers.get("referer") or headers.get("Referer")
-            if ['application/json', 'text/json', '*/*'].count(accept_header) > 0:
+            if ['application/json', 'text/json'].count(accept_header) > 0:
                 logger.debug(f"Returning JSON response with status code: {status_code}.")
                 return {
                     "statusCode": status_code,

--- a/subscriber/handler.py
+++ b/subscriber/handler.py
@@ -23,7 +23,7 @@ def run(event, context):
             accept_header = headers.get("accept") or headers.get("Accept")
             referer_header = headers.get("referer") or headers.get("Referer")
             if ['application/json', 'text/json', '*/*'].count(accept_header) > 0:
-                logger.debug(f"Returning JSON response with status code: {status_code}")
+                logger.debug(f"Returning JSON response with status code: {status_code}.")
                 return {
                     "statusCode": status_code,
                     "headers": {
@@ -32,6 +32,7 @@ def run(event, context):
                     "body": json.dumps({"message": message, "topics": topics})
                 }
             elif referer_header is not None:
+                logger.debug(f"Returning redirect response.")
                 return {
                     "statusCode": 302,
                     "headers": {
@@ -39,6 +40,7 @@ def run(event, context):
                     }
                 }
         
+        logger.debug(f"Returning HTML response with status code: {status_code}.")
         return {
             "statusCode": status_code,
             "headers": {

--- a/subscriber/serverless.yml
+++ b/subscriber/serverless.yml
@@ -40,7 +40,8 @@ functions:
     events:
       - httpApi:
           path: /
-          method: post
+          # support any method
+          method: '*'
 
 
 plugins:


### PR DESCRIPTION
This adds support for the GET method (and technically all methods, it doesn't matter).
The endpoint now redirects to the referrer if specified in the headers (`Referer`) with query strings: `message` and `topics`.
It also responds with JSON only if there is an `Accept` header with either of:
- `application/json`
- `text/json`

In all other cases, it responds with HTML.

Things not done: the message is always returned in the `message` query string (or JSON key) even for errors. The status code denotes if it was an error (500 or 400). The only exception is the redirection which always returns 302 in which case the caller does not know if there was an error. We could add a new parameter (`error: true|false`) to cover this case, but it won't cover cases where the AWS stack returns 500, so I'd rather ignore this minor case which only happens if the client does not support JS and receives an error.