### PR TITLE
Use vite JS API to build svelte app

### DIFF
--- a/generator/generate.js
+++ b/generator/generate.js
@@ -2,9 +2,8 @@ module.exports = async (dataFilePath, lastUpdatedFilePath, destinationDir) => {
   const fs = require("fs");
   const { build } = require("vite");
   const path = require("path");
-  const { execSync } = require("child_process");
   const writableRootDir = "/tmp/generator";
-  const svelteDir = "./svelte";
+  const svelteDir = path.join(writableRootDir, "svelte");
 
   // Create destination directory and writable root directory
   fs.mkdirSync(destinationDir, { recursive: true });
@@ -20,8 +19,6 @@ module.exports = async (dataFilePath, lastUpdatedFilePath, destinationDir) => {
     fs.cpSync(file, path.join(writableRootDir, file), { recursive: true });
   }
 
-  process.chdir(writableRootDir);
-
   // Copy data files to be used by Svelte
   fs.cpSync(dataFilePath, path.join(svelteDir, "src/routes/notified.json"));
   fs.cpSync(
@@ -29,8 +26,9 @@ module.exports = async (dataFilePath, lastUpdatedFilePath, destinationDir) => {
     path.join(svelteDir, "/src/routes/last_updated.txt")
   );
 
+  process.chdir(svelteDir);
+
   // Generate static site using vite
-  execSync("npm install", { stdio: "inherit" }); // Do we need this?
   await build();
 
   // Copy necessary static files to destination directory

--- a/generator/generate.js
+++ b/generator/generate.js
@@ -1,27 +1,31 @@
+const { build } = require('vite')
+const path = require('path')
+
 module.exports = async (dataFilePath, lastUpdatedFilePath, destinationDir) => {
     const fs = require('fs')
-    const { execSync } = require('child_process')
     const writableRootDir = '/tmp/generator'
-    const svelteDir = writableRootDir + '/svelte'
+    const svelteDir = './svelte'
 
     // Create destination directory and writable root directory
     fs.mkdirSync(destinationDir, { recursive: true })
     fs.mkdirSync(writableRootDir, { recursive: true })
 
+    process.chdir(writableRootDir)
+
     // Copy root directory to a writable location
     for (const file of ['svelte', 'package.json', 'package-lock.json', 'node_modules']) {
-        fs.cpSync(file, writableRootDir + '/' + file, { recursive: true })
+        fs.cpSync(file, file, { recursive: true })
     }
     
     // Copy data files to be used by Svelte
     fs.cpSync(dataFilePath, svelteDir + '/src/routes/notified.json')
     fs.cpSync(lastUpdatedFilePath, svelteDir + '/src/routes/last_updated.txt')
     
-    // Generate static site using Svelte
-    execSync('npm run build --workspace=svelte --cache=/tmp/cache --loglevel=verbose', { cwd: writableRootDir, stdio: 'inherit' })
+    // Generate static site using vite
+    await build()
 
     // Copy necessary static files to destination directory
-    const svelteBuildDir = svelteDir + '/build'
+    const svelteBuildDir = path.join(svelteDir, 'build')
     for (const file of ['/_app', '/index.html', '/favicon.png']) {
         fs.cpSync(svelteBuildDir + file, destinationDir + file, { recursive: true })
     }

--- a/generator/generate.js
+++ b/generator/generate.js
@@ -1,8 +1,7 @@
-const { build } = require("vite");
-const path = require("path");
-
 module.exports = async (dataFilePath, lastUpdatedFilePath, destinationDir) => {
   const fs = require("fs");
+  const { build } = require("vite");
+  const path = require("path");
   const { execSync } = require("child_process");
   const writableRootDir = "/tmp/generator";
   const svelteDir = "./svelte";
@@ -25,10 +24,13 @@ module.exports = async (dataFilePath, lastUpdatedFilePath, destinationDir) => {
 
   // Copy data files to be used by Svelte
   fs.cpSync(dataFilePath, path.join(svelteDir, "src/routes/notified.json"));
-  fs.cpSync(lastUpdatedFilePath, path.join(svelteDir, "/src/routes/last_updated.txt"));
+  fs.cpSync(
+    lastUpdatedFilePath,
+    path.join(svelteDir, "/src/routes/last_updated.txt")
+  );
 
   // Generate static site using vite
-  execSync("npm install", { stdio: "inherit" }) // Do we need this?
+  execSync("npm install", { stdio: "inherit" }); // Do we need this?
   await build();
 
   // Copy necessary static files to destination directory

--- a/generator/generate.js
+++ b/generator/generate.js
@@ -9,6 +9,7 @@ module.exports = async (dataFilePath, lastUpdatedFilePath, destinationDir) => {
     // Create destination directory and writable root directory
     fs.mkdirSync(destinationDir, { recursive: true })
     fs.mkdirSync(writableRootDir, { recursive: true })
+    fs.cpSync(svelteDir, path.join(writableRootDir, 'svelte'), { recursive: true })
 
     process.chdir(writableRootDir)
     

--- a/generator/generate.js
+++ b/generator/generate.js
@@ -11,6 +11,10 @@ module.exports = async (dataFilePath, lastUpdatedFilePath, destinationDir) => {
     fs.mkdirSync(writableRootDir, { recursive: true })
     fs.cpSync(svelteDir, path.join(writableRootDir, 'svelte'), { recursive: true })
 
+    for (const file of ['svelte', 'package.json', 'package-lock.json', 'node_modules']) {
+        fs.cpSync(file, writableRootDir + '/' + file, { recursive: true })
+    }
+    
     process.chdir(writableRootDir)
     
     // Copy data files to be used by Svelte

--- a/generator/generate.js
+++ b/generator/generate.js
@@ -10,6 +10,7 @@ module.exports = async (dataFilePath, lastUpdatedFilePath, destinationDir) => {
   fs.mkdirSync(writableRootDir, { recursive: true });
 
   // Copy necessary files to writable root directory
+  console.log(`Copying code files to writable root directory: ${writableRootDir}...`);
   for (const file of [
     "svelte",
     "package.json",
@@ -20,21 +21,27 @@ module.exports = async (dataFilePath, lastUpdatedFilePath, destinationDir) => {
   }
 
   // Copy data files to be used by Svelte
-  fs.cpSync(dataFilePath, path.join(svelteDir, "src/routes/notified.json"));
+  console.log(`Copying data files to svelte directory: ${svelteDir}...`);
+  fs.cpSync(
+    dataFilePath,
+    path.join(svelteDir, "src/routes/notified.json"));
   fs.cpSync(
     lastUpdatedFilePath,
-    path.join(svelteDir, "/src/routes/last_updated.txt")
+    path.join(svelteDir, "src/routes/last_updated.txt")
   );
 
+  console.log(`Changing directory to svelte directory: ${svelteDir}...`);
   process.chdir(svelteDir);
 
   // Generate static site using vite
+  console.log(`Building static site using vite...`);
   await build();
 
   // Copy necessary static files to destination directory
+  console.log(`Copying generated static files to destination directory: ${destinationDir}...`);
   const svelteBuildDir = path.join(svelteDir, "build");
-  for (const file of ["/_app", "/index.html", "/favicon.png"]) {
-    fs.cpSync(svelteBuildDir + file, destinationDir + file, {
+  for (const file of ["_app", "index.html", "favicon.png"]) {
+    fs.cpSync(path.join(svelteBuildDir, file), path.join(destinationDir, file), {
       recursive: true,
     });
   }

--- a/generator/generate.js
+++ b/generator/generate.js
@@ -11,11 +11,6 @@ module.exports = async (dataFilePath, lastUpdatedFilePath, destinationDir) => {
     fs.mkdirSync(writableRootDir, { recursive: true })
 
     process.chdir(writableRootDir)
-
-    // Copy root directory to a writable location
-    for (const file of ['svelte', 'package.json', 'package-lock.json', 'node_modules']) {
-        fs.cpSync(file, file, { recursive: true })
-    }
     
     // Copy data files to be used by Svelte
     fs.cpSync(dataFilePath, svelteDir + '/src/routes/notified.json')

--- a/generator/generate.js
+++ b/generator/generate.js
@@ -1,32 +1,41 @@
-const { build } = require('vite')
-const path = require('path')
+const { build } = require("vite");
+const path = require("path");
 
 module.exports = async (dataFilePath, lastUpdatedFilePath, destinationDir) => {
-    const fs = require('fs')
-    const writableRootDir = '/tmp/generator'
-    const svelteDir = './svelte'
+  const fs = require("fs");
+  const { execSync } = require("child_process");
+  const writableRootDir = "/tmp/generator";
+  const svelteDir = "./svelte";
 
-    // Create destination directory and writable root directory
-    fs.mkdirSync(destinationDir, { recursive: true })
-    fs.mkdirSync(writableRootDir, { recursive: true })
-    fs.cpSync(svelteDir, path.join(writableRootDir, 'svelte'), { recursive: true })
+  // Create destination directory and writable root directory
+  fs.mkdirSync(destinationDir, { recursive: true });
+  fs.mkdirSync(writableRootDir, { recursive: true });
 
-    for (const file of ['svelte', 'package.json', 'package-lock.json', 'node_modules']) {
-        fs.cpSync(file, writableRootDir + '/' + file, { recursive: true })
-    }
-    
-    process.chdir(writableRootDir)
-    
-    // Copy data files to be used by Svelte
-    fs.cpSync(dataFilePath, svelteDir + '/src/routes/notified.json')
-    fs.cpSync(lastUpdatedFilePath, svelteDir + '/src/routes/last_updated.txt')
-    
-    // Generate static site using vite
-    await build()
+  // Copy necessary files to writable root directory
+  for (const file of [
+    "svelte",
+    "package.json",
+    "package-lock.json",
+    "node_modules",
+  ]) {
+    fs.cpSync(file, path.join(writableRootDir, file), { recursive: true });
+  }
 
-    // Copy necessary static files to destination directory
-    const svelteBuildDir = path.join(svelteDir, 'build')
-    for (const file of ['/_app', '/index.html', '/favicon.png']) {
-        fs.cpSync(svelteBuildDir + file, destinationDir + file, { recursive: true })
-    }
-}
+  process.chdir(writableRootDir);
+
+  // Copy data files to be used by Svelte
+  fs.cpSync(dataFilePath, svelteDir + "/src/routes/notified.json");
+  fs.cpSync(lastUpdatedFilePath, svelteDir + "/src/routes/last_updated.txt");
+
+  // Generate static site using vite
+  execSync("npm install", { stdio: "inherit" }) // Do we need this?
+  await build();
+
+  // Copy necessary static files to destination directory
+  const svelteBuildDir = path.join(svelteDir, "build");
+  for (const file of ["/_app", "/index.html", "/favicon.png"]) {
+    fs.cpSync(svelteBuildDir + file, destinationDir + file, {
+      recursive: true,
+    });
+  }
+};

--- a/generator/generate.js
+++ b/generator/generate.js
@@ -24,8 +24,8 @@ module.exports = async (dataFilePath, lastUpdatedFilePath, destinationDir) => {
   process.chdir(writableRootDir);
 
   // Copy data files to be used by Svelte
-  fs.cpSync(dataFilePath, svelteDir + "/src/routes/notified.json");
-  fs.cpSync(lastUpdatedFilePath, svelteDir + "/src/routes/last_updated.txt");
+  fs.cpSync(dataFilePath, path.join(svelteDir, "src/routes/notified.json"));
+  fs.cpSync(lastUpdatedFilePath, path.join(svelteDir, "/src/routes/last_updated.txt"));
 
   // Generate static site using vite
   execSync("npm install", { stdio: "inherit" }) // Do we need this?


### PR DESCRIPTION
This PR imports the `build` function from vite and uses it directly instead of executing a shell command.

It's the second step to solve #20 after #35 (Use npm workspaces PR)

### Why do #35 first?

The requirement was to be able to run vite JS functions from `generator.js`, to import `vite` from there, we needed to have one `node_modules` file in the same place.

Svelte is just a plugin for vite, running vite build is the same as building the svelte app, by using `process.chdir` to the `svelte` directory, it picks the correct `vite.config.ts` file and the correct `app.html` input file which is used by `rollup` to bundle our output app.