### PR TITLE
Fix toasts rendering issues

### DIFF
--- a/generator/svelte/src/lib/service.ts
+++ b/generator/svelte/src/lib/service.ts
@@ -19,7 +19,7 @@ export const subscribeToMasjid = async ({ email, topics }: ISubscribeArgs) => {
 	const data = (await response.json()) satisfies ISubscribeResponse;
 
 	if (!response.ok) {
-		toast.error(data?.message ?? 'An error occurred');
+		return toast.error(data?.message ?? 'An error occurred');
 	}
 
 	data.message && toast.success(data.message);

--- a/generator/svelte/src/lib/stores/toast.ts
+++ b/generator/svelte/src/lib/stores/toast.ts
@@ -5,7 +5,7 @@ import { writable } from 'svelte/store';
 export const toasts = writable<IToast[]>([]);
 
 const addToast = (type: EAlertType, message: string) => {
-	toasts.update((t) => [...t, { type, message, id: Date.now() }]);
+	toasts.update((t) => [{ type, message, id: Date.now() }, ...t]);
 
 	setTimeout(() => {
 		toasts.update((t) => t.filter((toast) => toast.id !== t[0].id));

--- a/generator/svelte/src/lib/stores/toast.ts
+++ b/generator/svelte/src/lib/stores/toast.ts
@@ -5,10 +5,10 @@ import { writable } from 'svelte/store';
 export const toasts = writable<IToast[]>([]);
 
 const addToast = (type: EAlertType, message: string) => {
-	toasts.update((t) => [...t, { type, message }]);
+	toasts.update((t) => [...t, { type, message, id: Date.now() }]);
 
 	setTimeout(() => {
-		toasts.update((t) => t.filter((x) => x.message !== message));
+		toasts.update((t) => t.filter((toast) => toast.id !== t[0].id));
 	}, TOAST_TIMEOUT);
 };
 

--- a/generator/svelte/src/lib/types.ts
+++ b/generator/svelte/src/lib/types.ts
@@ -3,6 +3,7 @@ import type { EAlertType } from './constants';
 export interface IToast {
 	type: EAlertType;
 	message: string;
+	id: number;
 }
 
 export interface ISubscribeArgs {

--- a/generator/svelte/src/routes/+layout.svelte
+++ b/generator/svelte/src/routes/+layout.svelte
@@ -9,7 +9,7 @@
 <ul
 	class="fixed inset-0 top-navbar left-1/2 -translate-x-1/2 translate-y-8 flex flex-col gap-4 z-[200] pointer-events-none"
 >
-	{#each $toasts as toast (toast.message)}
+	{#each $toasts as toast (toast.id)}
 		<li class="pointer-events-auto" animate:flip>
 			<Toast type={toast.type}>
 				{toast.message}


### PR DESCRIPTION
- Add `id` property to toasts. This way adding/removing toasts won't confuse rendering, and each toast should disappear after 5 seconds without impacting others.
- Fix 2 toasts appearing after a single API request.
- Make the most recent toast appear first on the list.