### PR TITLE
Fix website look in mobile devices

### DIFF
--- a/generator/svelte/src/app.css
+++ b/generator/svelte/src/app.css
@@ -1,3 +1,11 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+body {
+	overflow: auto;
+}
+
+body:has(.drawer-toggle:checked) {
+	overflow: hidden;
+}

--- a/generator/svelte/src/lib/components/Navbar.svelte
+++ b/generator/svelte/src/lib/components/Navbar.svelte
@@ -19,23 +19,5 @@
 				/>
 			</div>
 		</form>
-		<button class="btn btn-ghost btn-circle">
-			<div class="indicator">
-				<svg
-					xmlns="http://www.w3.org/2000/svg"
-					class="h-5 w-5"
-					fill="none"
-					viewBox="0 0 24 24"
-					stroke="currentColor"
-					><path
-						stroke-linecap="round"
-						stroke-linejoin="round"
-						stroke-width="2"
-						d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"
-					/></svg
-				>
-				<span class="badge badge-xs badge-primary indicator-item" />
-			</div>
-		</button>
 	</div>
 </nav>

--- a/generator/svelte/src/routes/+page.svelte
+++ b/generator/svelte/src/routes/+page.svelte
@@ -91,7 +91,7 @@
 			<Spacer />
 		{/if}
 
-		<div class="px-8 w-full capitalize">
+		<div class="w-full capitalize">
 			{#each masjids as [name, { iqamas, jumas }], i}
 				<h2 class="flex items-center justify-between">
 					<span>{name}</span>


### PR DESCRIPTION
- Remove bell icon from the navbar
- Remove horizontal padding for masjids list on all screen sizes
- Disable scrolling the main website content when side-over is open (CSS-only solution)

### Drawbacks
- The has selector is not yet supported on Firefox and Firefox for Android/IOS. They are working on it this time. It's also not supported on UC Browser & Opera Mini. Using the app on these devices will work, but the SideOver will not be the best when you try to scroll.

Looks cleaner this way!

<img src="https://github.com/hammady/wwpray/assets/49946791/ba127b69-6541-4cb6-a598-e38012dc3c88" alt="website look on Android device" width="400px" />