### PR TITLE
Add masjid metadata

### DIFF
--- a/generator/svelte/src/lib/components/app/MasjidsList.svelte
+++ b/generator/svelte/src/lib/components/app/MasjidsList.svelte
@@ -21,9 +21,11 @@
 </script>
 
 <div class="w-full">
-	{#each masjids as [name, { iqamas, jumas }], i}
+	{#each masjids as [name, { display_name: displayName, address, website, iqamas, jumas }], i}
 		<h2 class="flex items-center justify-between">
-			<span>{name}</span>
+			<a href={website}>
+				{displayName}
+			</a>
 
 			<button on:click={() => onMasjidSubscribeClick(name)}>
 				<label class="btn btn-primary btn-sm drawer-button" for={SUBSCRIPTION_SIDEOVER_ID}>
@@ -31,6 +33,8 @@
 				</label>
 			</button>
 		</h2>
+
+		<p>Address: {address}</p>
 
 		<div class="overflow-x-auto px-4">
 			<table class="table table-zebra">

--- a/generator/svelte/src/lib/components/app/SubscribeForm.svelte
+++ b/generator/svelte/src/lib/components/app/SubscribeForm.svelte
@@ -61,11 +61,11 @@
 		<span>Which masjids do you want to subscribe to?</span>
 	</label>
 	<ul class="w-full mt-1" bind:this={masjidsListElement}>
-		{#each masjids as [name]}
+		{#each masjids as [id, { display_name: name }]}
 			<li>
 				<label class="label justify-start cursor-pointer my-1">
 					<input
-						id={name}
+						{id}
 						type="checkbox"
 						name="topics"
 						class="checkbox checkbox-primary"

--- a/generator/svelte/src/lib/types.ts
+++ b/generator/svelte/src/lib/types.ts
@@ -19,4 +19,7 @@ export interface ISubscribeResponse {
 export interface IMasjid {
 	iqamas: Record<string, { time: string }>;
 	jumas: string[];
+	display_name: string;
+	address: string;
+	website: string;
 }


### PR DESCRIPTION
- Use `display_name` for the masjid heading.
- Make the masjid name clickable and link to the masjid website.
- Add the address below the masjid name.

## Screenshots (non-real data)
![image](https://github.com/hammady/wwpray/assets/49946791/1e9958d3-b113-46e4-a8bb-5fd63207a759)

![image](https://github.com/hammady/wwpray/assets/49946791/8ff170b6-cb09-43ff-a69b-4d27f8bb5705)
