### PR TITLE
Upload layout files without the .html extension

### DIFF
--- a/generator/generate.js
+++ b/generator/generate.js
@@ -45,10 +45,15 @@ module.exports = async (dataFilePath, destinationDir) => {
   // Copy necessary static files to destination directory
   console.log(`Copying generated static files to destination directory: ${destinationDir}...`);
   const svelteBuildDir = path.join(svelteDir, "build");
-  const layouts = ["index.html", "jumas.html", "masjids.html"]
-  for (const file of ["_app", "favicon.png"].concat(layouts)) {
+  for (const file of ["index.html", "_app", "favicon.png"]) {
     fs.cpSync(path.join(svelteBuildDir, file), path.join(destinationDir, file), {
       recursive: true,
     });
+  }
+  // layouts need to be handled separately to make them http navigable
+  for (const file of ["jumas.html", "masjids.html"]) {
+    // strip .html extension
+    const destFileName = file.replace(".html", "");
+    fs.cpSync(path.join(svelteBuildDir, file), path.join(destinationDir, destFileName));
   }
 };

--- a/generator/index.js
+++ b/generator/index.js
@@ -32,6 +32,7 @@ module.exports.handler = async (event, context) => {
     const ext = require('path').extname(filePath)
     switch (ext) {
       case '.html':
+      case '':
         return 'text/html; charset=utf-8'
       case '.css':
         return 'text/css; charset=utf-8'


### PR DESCRIPTION
This strips the `.html` extension from layout files before uploading.
This makes refreshing a URL like `host/jumas` correctly load the layout file at `jumas`.

Closes #73.