### PR TITLE
Fix Changed-On date being 1 day behind

### DIFF
--- a/generator/svelte/src/lib/components/app/PrayerTimeChanged.svelte
+++ b/generator/svelte/src/lib/components/app/PrayerTimeChanged.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
+	import { browser } from '$app/environment';
 	import { convertToCalendarTime, isOlderThanAWeek, isToday, isYesterday, tw } from '$lib/utils';
 
 	export let changedOn: string | undefined;
 
-	$: today = changedOn && isToday(changedOn);
-	$: yesterday = changedOn && isYesterday(changedOn);
-	$: olderThanAWeek = changedOn && isOlderThanAWeek(changedOn);
+	$: today = changedOn && browser && isToday(changedOn);
+	$: yesterday = changedOn && browser && isYesterday(changedOn);
+	$: olderThanAWeek = changedOn && browser && isOlderThanAWeek(changedOn);
 	$: changedOnCalendarTime = convertToCalendarTime(changedOn);
 </script>
 

--- a/generator/svelte/src/lib/utils.ts
+++ b/generator/svelte/src/lib/utils.ts
@@ -16,10 +16,16 @@ export const convertToRelativeTime = (isoDate: string) => {
 	return dayjs.utc(isoDate).fromNow();
 };
 
-export const convertToCalendarTime = (isoDate?: string) => {
-	if (!isoDate) return null;
+export const convertToCalendarTime = (dateStr?: string) => {
+	if (!dateStr) return null;
 
+<<<<<<< Updated upstream
 	return dayjs.utc(isoDate).local().calendar(null, {
+||||||| Stash base
+	return dayjs.utc(isoDate).calendar(null, {
+=======
+	return dayjs.utc(dateStr).calendar(null, {
+>>>>>>> Stashed changes
 		sameDay: '[Today]',
 		nextDay: '[Tomorrow]',
 		nextWeek: '[Next Week]',

--- a/generator/svelte/src/lib/utils.ts
+++ b/generator/svelte/src/lib/utils.ts
@@ -19,13 +19,7 @@ export const convertToRelativeTime = (isoDate: string) => {
 export const convertToCalendarTime = (dateStr?: string) => {
 	if (!dateStr) return null;
 
-<<<<<<< Updated upstream
-	return dayjs.utc(isoDate).local().calendar(null, {
-||||||| Stash base
-	return dayjs.utc(isoDate).calendar(null, {
-=======
-	return dayjs.utc(dateStr).calendar(null, {
->>>>>>> Stashed changes
+	return dayjs.utc(dateStr).local().calendar(null, {
 		sameDay: '[Today]',
 		nextDay: '[Tomorrow]',
 		nextWeek: '[Next Week]',

--- a/generator/svelte/src/lib/utils.ts
+++ b/generator/svelte/src/lib/utils.ts
@@ -19,7 +19,7 @@ export const convertToRelativeTime = (isoDate: string) => {
 export const convertToCalendarTime = (isoDate?: string) => {
 	if (!isoDate) return null;
 
-	return dayjs.utc(isoDate).calendar(null, {
+	return dayjs.utc(isoDate).local().calendar(null, {
 		sameDay: '[Today]',
 		nextDay: '[Tomorrow]',
 		nextWeek: '[Next Week]',
@@ -30,15 +30,15 @@ export const convertToCalendarTime = (isoDate?: string) => {
 };
 
 export const isToday = (isoDate: string) => {
-	return dayjs.utc(isoDate).isSame(dayjs.utc(), 'day');
+	return dayjs(isoDate).isSame(dayjs(), 'day');
 };
 
 export const isYesterday = (isoDate: string) => {
-	return dayjs.utc(isoDate).isSame(dayjs.utc().subtract(1, 'day'), 'day');
+	return dayjs(isoDate).isSame(dayjs().subtract(1, 'day'), 'day');
 };
 
 export const isOlderThanAWeek = (isoDate: string) => {
-	return dayjs.utc(isoDate).isBefore(dayjs.utc().subtract(7, 'day'), 'day');
+	return dayjs(isoDate).isBefore(dayjs().subtract(7, 'day'), 'day');
 };
 
 export const getCurrentLocalDateTime = () => {

--- a/generator/svelte/src/lib/utils.ts
+++ b/generator/svelte/src/lib/utils.ts
@@ -29,8 +29,8 @@ export const convertToCalendarTime = (isoDate?: string) => {
 	});
 };
 
-export const isToday = (isoDate: string) => {
-	return dayjs(isoDate).isSame(dayjs(), 'day');
+export const isToday = (dateStr: string) => {
+	return dayjs(dateStr).isSame(dayjs(), 'day');
 };
 
 export const isYesterday = (isoDate: string) => {


### PR DESCRIPTION
If we parse "28-10-2023", which isn't an ISO Date, it will be treated as 12:00AM, and then we compare it with the current UTC time that date will be older so it will be shown as "Yesterday" instead of "Today" and so on.

This PR gets the current time using the local time, it will be the same as the client timezone.

# Screenshot

![image](https://github.com/hammady/wwpray/assets/49946791/51883680-f44c-42b1-91da-4b35c8ab307d)
