### PR TITLE
Fix next prayer calculation and add tests

### DIFF
--- a/.github/workflows/sls-generator.yaml
+++ b/.github/workflows/sls-generator.yaml
@@ -1,6 +1,6 @@
 # github action to deploy generator sls service to prod
 
-name: Deploy generator service to prod
+name: Test (always) and deploy (on push) generator service
 
 on:
   push:
@@ -13,8 +13,8 @@ on:
     paths: *generator_paths
 
 jobs:
-  deploy:
-    name: Deploy
+  test-and-deploy:
+    name: Test and (if push) deploy
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/sls-generator.yaml
+++ b/.github/workflows/sls-generator.yaml
@@ -6,9 +6,11 @@ on:
   push:
     branches:
       - main
-    paths:
+    paths: &generator_paths
       - generator/**
       - .github/workflows/sls-generator.yaml
+  pull_request:
+    paths: *generator_paths
 
 jobs:
   deploy:
@@ -32,11 +34,15 @@ jobs:
       - name: Install node dependencies
         working-directory: generator
         run: npm ci
+      - name: Run unit tests
+        working-directory: generator/svelte
+        run: npm run test:unit
       - name: Install python3.9
         uses: actions/setup-python@v2
         with:
           python-version: '3.9'
       - name: Package and deploy
+        if: github.event_name == 'push'
         working-directory: generator
         run: |
           serverless deploy \

--- a/.github/workflows/sls-notifier.yaml
+++ b/.github/workflows/sls-notifier.yaml
@@ -6,9 +6,11 @@ on:
   push:
     branches:
       - main
-    paths:
+    paths: &notifier_paths
       - notifier/**
       - .github/workflows/sls-notifier.yaml
+  pull_request:
+    paths: *notifier_paths
 
 jobs:
   deploy:
@@ -32,11 +34,15 @@ jobs:
       - name: Install node dependencies
         working-directory: notifier
         run: npm ci
+      - name: Run tests
+        working-directory: notifier
+        run: npm run test
       - name: Install python3.9
         uses: actions/setup-python@v2
         with:
           python-version: '3.9'
       - name: Package and deploy
+        if: github.event_name == 'push'
         working-directory: notifier
         run: |
           serverless deploy \

--- a/.github/workflows/sls-notifier.yaml
+++ b/.github/workflows/sls-notifier.yaml
@@ -1,6 +1,6 @@
 # github action to deploy notifier sls service to prod
 
-name: Deploy notifier service to prod
+name: Test (always) and deploy (on push) notifier service
 
 on:
   push:
@@ -13,8 +13,8 @@ on:
     paths: *notifier_paths
 
 jobs:
-  deploy:
-    name: Deploy
+  test-and-deploy:
+    name: Test and (if push) deploy
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/sls-scraper.yaml
+++ b/.github/workflows/sls-scraper.yaml
@@ -1,6 +1,6 @@
 # github action to deploy scraper sls service to prod
 
-name: Deploy scraper service to prod
+name: Test (always) and deploy (on push) scraper service
 
 on:
   push:
@@ -13,8 +13,8 @@ on:
     paths: *scraper_paths
 
 jobs:
-  deploy:
-    name: Deploy
+  test-and-deploy:
+    name: Test and (if push) deploy
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/sls-scraper.yaml
+++ b/.github/workflows/sls-scraper.yaml
@@ -6,9 +6,11 @@ on:
   push:
     branches:
       - main
-    paths:
+    paths: &scraper_paths
       - scraper/**
       - .github/workflows/sls-scraper.yaml
+  pull_request:
+    paths: *scraper_paths
 
 jobs:
   deploy:
@@ -32,11 +34,15 @@ jobs:
       - name: Install node dependencies
         working-directory: scraper
         run: npm ci
+      - name: Run tests
+        working-directory: scraper
+        run: npm run test
       - name: Install python3.9
         uses: actions/setup-python@v2
         with:
           python-version: '3.9'
       - name: Package and deploy
+        if: github.event_name == 'push'
         working-directory: scraper
         run: |
           serverless deploy \

--- a/generator/svelte/package.json
+++ b/generator/svelte/package.json
@@ -12,7 +12,7 @@
 		"lint": "prettier --plugin-search-dir . --check . && eslint .",
 		"format": "prettier --plugin-search-dir . --write .",
 		"test:integration": "playwright test",
-		"test:unit": "vitest"
+		"test:unit": "vitest run --reporter verbose"
 	},
 	"devDependencies": {
 		"@playwright/test": "^1.28.1",

--- a/generator/svelte/src/index.test.ts
+++ b/generator/svelte/src/index.test.ts
@@ -1,7 +1,0 @@
-import { describe, it, expect } from 'vitest';
-
-describe('sum test', () => {
-	it('adds 1 + 2 to equal 3', () => {
-		expect(1 + 2).toBe(3);
-	});
-});

--- a/generator/svelte/src/lib/utils.test.ts
+++ b/generator/svelte/src/lib/utils.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { getNextPrayerForMasjids } from './utils';
+import { getTimeRemainingForNextPrayer } from './utils';
+import type { IMasjid } from './types';
+
+// Helper to create a masjid with specific iqama times
+function makeMasjid(iqamas: Record<string, number>): IMasjid {
+	return {
+		display_name: 'Test Masjid',
+		address: '123 Test St',
+		website: '',
+		last_updated: '',
+		jumas: [],
+		iqamas: Object.fromEntries(
+			Object.entries(iqamas).map(([name, seconds]) => [name, { time: '', seconds_since_midnight_utc: seconds }])
+		)
+	};
+}
+
+// Helper to create a pair of masjids A and B
+function makeMasjidPair(): [string, IMasjid][] {
+	return [
+		['A', makeMasjid({ fajr: 25000, zuhr: 40000, asr: 60000, maghrib: 80000, isha: 90000 })],
+		['B', makeMasjid({ fajr: 26000, zuhr: 41000, asr: 61000, maghrib: 81000, isha: 91000 })],
+	];
+}
+
+describe('getNextPrayerForMasjids', () => {
+	it('returns the next prayer when all prayers are in the future', () => {
+		const now = 20000; // 5:33 AM
+		const masjids = makeMasjidPair();
+		const result = getNextPrayerForMasjids(masjids, now);
+		expect(result?.name).toBe('fajr');
+	});
+
+	it('returns the next closest prayer by latest iqama time', () => {
+		const now = 30000; // 8:00 AM
+		const masjids = makeMasjidPair();
+		const result = getNextPrayerForMasjids(masjids, now);
+		expect(result?.name).toBe('zuhr');
+	});
+
+	it('returns the next prayer even if current time is after zuhr for A but before zuhr for B', () => {
+		const now = 40500; // 11:21:40 AM
+		const masjids = makeMasjidPair();
+		const result = getNextPrayerForMasjids(masjids, now);
+		expect(result?.name).toBe('zuhr');
+	});
+
+	it('returns the first prayer if all are in the past', () => {
+		const now = 95000; // after isha
+		const masjids = makeMasjidPair();
+		const result = getNextPrayerForMasjids(masjids, now);
+		expect(result?.name).toBe('fajr');
+	});
+
+	it('returns undefined if masjids is empty', () => {
+		const result = getNextPrayerForMasjids([]);
+		expect(result).toBeUndefined();
+	});
+});
+
+describe('getTimeRemainingForNextPrayer', () => {
+	it('returns correct time remaining for next prayer when all prayers are in the future', () => {
+		const now = 20000; // 5:33 AM
+		const masjids = makeMasjidPair();
+		const result = getTimeRemainingForNextPrayer(masjids, now);
+		// Next prayer is fajr at 25000 (A), so 25000-20000 = 5000 seconds
+		// 5000 seconds = 1 hour, 23 minutes, 20 seconds
+		expect(result).toEqual({ hours: 1, minutes: 23, seconds: 20 });
+	});
+
+	it('returns correct time remaining for next prayer just before zuhr', () => {
+		const now = 40900; // 11:21:40 AM
+		const masjids = makeMasjidPair();
+		const result = getTimeRemainingForNextPrayer(masjids, now);
+		// Next prayer is zuhr at 41000 (A), so 41000-40900 = 100 seconds
+		// 100 seconds = 1 minute, 40 seconds
+		expect(result).toEqual({ hours: 0, minutes: 1, seconds: 40 });
+	});
+
+	it('returns correct time remaining for next prayer after zuhr', () => {
+		const now = 41100; // after zuhr for both, next is asr
+		const masjids = makeMasjidPair();
+		const result = getTimeRemainingForNextPrayer(masjids, now);
+		// Next prayer is asr at 60000 (A), so 60000-41100 = 18900 seconds
+		// 18900 seconds = 5 hours, 15 minutes, 0 seconds
+		expect(result).toEqual({ hours: 5, minutes: 15, seconds: 0 });
+	});
+
+	it('returns correct time remaining for next prayer after isha (wraps to fajr)', () => {
+		const now = 95000; // after isha
+		const masjids = makeMasjidPair();
+		const result = getTimeRemainingForNextPrayer(masjids, now);
+		// Next prayer is fajr at 25000 (A), so 25000-95000 = -70000 + 86400 = 16400
+		// 16400 seconds = 4 hours, 33 minutes, 20 seconds
+		expect(result).toEqual({ hours: 4, minutes: 33, seconds: 20 });
+	});
+
+	it('returns null if masjids is empty', () => {
+		const result = getTimeRemainingForNextPrayer([], 20000);
+		expect(result).toBeNull();
+	});
+});


### PR DESCRIPTION
## Fix next prayer logic, improve testability, and CI reliability

### Summary

This PR addresses several issues and improvements across the codebase and CI workflows:

- **Corrects next prayer and time remaining logic:**  
  - Refactored `getNextPrayerForMasjids` and `getTimeRemainingForNextPrayer` to ensure the next prayer and its time remaining are always calculated correctly across all masjids, including proper handling of day wrapping.
  - Ensured both functions are testable by allowing a mockable `now` argument.

- **Test improvements:**  
  - Added tests for `getNextPrayerForMasjids` and `getTimeRemainingForNextPrayer` to cover edge cases, including after-isha wrapping.

- **CI workflow enhancements:**  
  - Added test steps to the `sls-generator`, `sls-notifier`, and `sls-scraper` GitHub Actions workflows.
  - Ensured tests run on both `push` and `pull_request` events, but deployment only occurs on `push` to `main`.

Closes #90.